### PR TITLE
feat: add validation messages for project identifier errors

### DIFF
--- a/src/main/java/com/projectmanagement/tool/exceptions/CustomResponseEntityExceptionHandler.java
+++ b/src/main/java/com/projectmanagement/tool/exceptions/CustomResponseEntityExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.projectmanagement.tool.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice // a global handler for controller exceptions
+@RestController
+public class CustomResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler
+  public final ResponseEntity <Object>handleProjectIdException(
+      ProjectIdException projectIdException, WebRequest request) {
+    ProjectIdExceptionResponse exceptionResponse =
+        new ProjectIdExceptionResponse(projectIdException.getMessage());
+    return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/com/projectmanagement/tool/exceptions/ProjectIdException.java
+++ b/src/main/java/com/projectmanagement/tool/exceptions/ProjectIdException.java
@@ -1,0 +1,11 @@
+package com.projectmanagement.tool.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class ProjectIdException extends RuntimeException {
+  public ProjectIdException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/projectmanagement/tool/exceptions/ProjectIdExceptionResponse.java
+++ b/src/main/java/com/projectmanagement/tool/exceptions/ProjectIdExceptionResponse.java
@@ -1,0 +1,18 @@
+package com.projectmanagement.tool.exceptions;
+
+public class ProjectIdExceptionResponse {
+
+  public ProjectIdExceptionResponse(String projectIdentifier) {
+    this.projectIdentifier = projectIdentifier;
+  }
+
+  public String getProjectIdentifier() {
+    return projectIdentifier;
+  }
+
+  public void setProjectIdentifier(String projectIdentifier) {
+    this.projectIdentifier = projectIdentifier;
+  }
+
+  private String projectIdentifier;
+}

--- a/src/main/java/com/projectmanagement/tool/services/ProjectService.java
+++ b/src/main/java/com/projectmanagement/tool/services/ProjectService.java
@@ -1,6 +1,7 @@
 package com.projectmanagement.tool.services;
 
 import com.projectmanagement.tool.domain.Project;
+import com.projectmanagement.tool.exceptions.ProjectIdException;
 import com.projectmanagement.tool.repositories.ProjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,8 +16,13 @@ public class ProjectService {
   }
 
   public void saveOrUpdateProject(Project project) {
+    try {
+      project.setProjectIdentifier(project.getProjectIdentifier().toUpperCase());
+      projectRepository.save(project);
 
-    // logic
-    projectRepository.save(project);
+    } catch (Exception e) {
+      throw new ProjectIdException(
+          "Project id'" + project.getProjectIdentifier().toUpperCase() + "'already exists");
+    }
   }
 }


### PR DESCRIPTION
- Implemented custom handling for duplicate projects trying to be persisted into the database.
- Extracted message from runtime exceptions and fed it as an EntityResponse to the controller